### PR TITLE
Enhanced: adding a new script in order to check norminette only in relevant files

### DIFF
--- a/check_norm.sh
+++ b/check_norm.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+norminette srcs/ includes/ libft/


### PR DESCRIPTION
I added the script ./check_norm so we can check norminette errors while excluding our tests files.